### PR TITLE
deflateInitにlevelオプションを指定できるようにする

### DIFF
--- a/lib/stream_gzip.ex
+++ b/lib/stream_gzip.ex
@@ -46,9 +46,10 @@ defmodule StreamGzip do
       <<31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 171, 168, 172, 170, 168, 172, 2, 0, 60, 143, 60, 178, 6, 0, 0, 0>>
   """
   @spec gzip(Enumerable.t) :: Enumerable.t
-  def gzip(enum) do
+  def gzip(enum), do: gzip enum, level: :default
+  def gzip(enum, opts) do
     z = :zlib.open
-    :zlib.deflateInit z, :default, :deflated, 16 + 15, 8, :default
+    :zlib.deflateInit z, opts[:level] || :default, :deflated, 16 + 15, 8, :default
     transform_with_final enum, z, &{:zlib.deflate(&2, &1), &2}, fn z ->
       iolist = :zlib.deflate z, "", :finish
       :zlib.deflateEnd z

--- a/lib/stream_gzip.ex
+++ b/lib/stream_gzip.ex
@@ -47,6 +47,7 @@ defmodule StreamGzip do
   """
   @spec gzip(Enumerable.t) :: Enumerable.t
   def gzip(enum), do: gzip enum, level: :default
+  @spec gzip(Enumerable.t, map) :: Enumerable.t
   def gzip(enum, opts) do
     z = :zlib.open
     :zlib.deflateInit z, opts[:level] || :default, :deflated, 16 + 15, 8, :default

--- a/lib/stream_gzip.ex
+++ b/lib/stream_gzip.ex
@@ -47,10 +47,10 @@ defmodule StreamGzip do
   """
   @spec gzip(Enumerable.t) :: Enumerable.t
   def gzip(enum), do: gzip enum, level: :default
-  @spec gzip(Enumerable.t, map) :: Enumerable.t
+  @spec gzip(Enumerable.t, level: (:none | :default | :best_compression | :best_speed | 0..9)) :: Enumerable.t
   def gzip(enum, opts) do
     z = :zlib.open
-    :zlib.deflateInit z, opts[:level] || :default, :deflated, 16 + 15, 8, :default
+    :zlib.deflateInit z, (opts[:level] || :default), :deflated, 16 + 15, 8, :default
     transform_with_final enum, z, &{:zlib.deflate(&2, &1), &2}, fn z ->
       iolist = :zlib.deflate z, "", :finish
       :zlib.deflateEnd z

--- a/test/stream_gzip_test.exs
+++ b/test/stream_gzip_test.exs
@@ -35,15 +35,15 @@ defmodule StreamGzipTest do
     test "deflateInit level option" do
       expected = "test/fixture/sample.txt"
         |> File.stream!
-        |> StreamGzip.gzip(%{level: :best_speed})
+        |> StreamGzip.gzip(level: :best_speed)
+        |> StreamGzip.gunzip
         |> StreamHash.hash(:sha256)
         |> Enum.to_list
-      actual = "test/fixture/sample.txt.gz"
+      actual = "test/fixture/sample.txt"
         |> File.stream!
         |> StreamHash.hash(:sha256)
         |> Enum.to_list
-      refute expected == actual
-      assert expected != ""
+      assert expected == actual
     end
   end
 end

--- a/test/stream_gzip_test.exs
+++ b/test/stream_gzip_test.exs
@@ -31,5 +31,19 @@ defmodule StreamGzipTest do
         |> Enum.to_list
       assert expected == actual
     end
+
+    test "deflateInit level option" do
+      expected = "test/fixture/sample.txt"
+        |> File.stream!
+        |> StreamGzip.gzip(%{level: :best_speed})
+        |> StreamHash.hash(:sha256)
+        |> Enum.to_list
+      actual = "test/fixture/sample.txt.gz"
+        |> File.stream!
+        |> StreamHash.hash(:sha256)
+        |> Enum.to_list
+      refute expected == actual
+      assert expected != ""
+    end
   end
 end


### PR DESCRIPTION
## 関連URL

* [Erlangのzlibのドキュメント](http://erlang.org/doc/man/zlib.html#type-zlevel)

## 概要

* zlibのdeflateInitのlevelオプションを引数で指定できるようにした

## 技術的変更点概要

* 何も指定しない場合は、levelに:defaultが渡るようにしています。

## 変更の確認項目

* [x] deflateInitにlevelオプションが指定可能となる

## 今回保留した項目とTODOリスト

## マージ・リリースする際の注意点

## その他
テストが微妙です…どういうテストが良いですかね…

