### PR TITLE
Update unzip example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Gunzip:
 
 ```elixir
 "x.gz"
-|> File.stream!
+|> File.stream!([:binary], 1024)
 |> StreamGzip.gunzip
 |> Enum.into("")
 ```


### PR DESCRIPTION
Using `File.stream!` with the default options will perform line-ending normalization on the incoming data, transforming `\r\n` into `\n` and likely breaking the file.

The options added here match the ones used in the tests for `StreamGzip.gunzip`.